### PR TITLE
Fix service worker scope for subdirectory deployments

### DIFF
--- a/js/pwa.js
+++ b/js/pwa.js
@@ -16,7 +16,7 @@
 
   window.addEventListener('load', async () => {
     try {
-      const reg = await navigator.serviceWorker.register('/service-worker.js');
+      const reg = await navigator.serviceWorker.register('./service-worker.js');
       function onNewSW(sw){
         const banner = ensureBanner();
         banner.style.display = 'block';

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,14 +1,16 @@
 // Enhanced SW with versioned cache + skipWaiting + data.json bypass
-const SW_VERSION = '1758951308';
+const SW_VERSION = '1759050000';
 const CACHE_NAME = 'pwa-cache-v' + SW_VERSION;
+const INDEX_PATH = new URL('index.html', self.location).pathname;
 const ASSETS = [
-  '/', '/index.html',
-  '/manifest.json',
-  '/css/style.css',
-  '/js/app.js',
-  '/js/pwa.js',
-  '/js/limits.js',
-  '/js/admin-inline.js'
+  new URL('./', self.location).pathname,
+  new URL('index.html', self.location).pathname,
+  new URL('manifest.json', self.location).pathname,
+  new URL('css/style.css', self.location).pathname,
+  new URL('js/app.js', self.location).pathname,
+  new URL('js/pwa.js', self.location).pathname,
+  new URL('js/limits.js', self.location).pathname,
+  new URL('js/admin-inline.js', self.location).pathname
   // NOTE: deliberately NOT caching /data.json
 ];
 
@@ -46,10 +48,10 @@ self.addEventListener('fetch', (event) => {
   if (event.request.mode === 'navigate') {
     event.respondWith((async () => {
       const cache = await caches.open(CACHE_NAME);
-      const cached = await cache.match('/index.html');
+      const cached = await cache.match(INDEX_PATH);
       try {
         const fresh = await fetch(event.request);
-        cache.put('/index.html', fresh.clone());
+        cache.put(INDEX_PATH, fresh.clone());
         return fresh;
       } catch (e) {
         return cached || Response.error();


### PR DESCRIPTION
## Summary
- register the service worker with a relative URL so it works when hosted from a subdirectory
- normalize cached asset URLs to the service worker scope and bump the cache version for deployment

## Testing
- python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68d7b626229c8321b10f37fbf803b37a