### PR TITLE
Fix service worker scope handling for subdirectory deployments

### DIFF
--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,6 +1,7 @@
 
 (function(){
   const id = 'updateBanner';
+  const scriptUrl = (document.currentScript && document.currentScript.src) || new URL('js/pwa.js', window.location.href).href;
   function ensureBanner(){
     let b = document.getElementById(id);
     if (b) return b;
@@ -16,7 +17,8 @@
 
   window.addEventListener('load', async () => {
     try {
-      const reg = await navigator.serviceWorker.register('./service-worker.js');
+      const swUrl = new URL('../service-worker.js', scriptUrl);
+      const reg = await navigator.serviceWorker.register(swUrl.pathname);
       function onNewSW(sw){
         const banner = ensureBanner();
         banner.style.display = 'block';

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,16 +1,17 @@
 // Enhanced SW with versioned cache + skipWaiting + data.json bypass
 const SW_VERSION = '1759050000';
 const CACHE_NAME = 'pwa-cache-v' + SW_VERSION;
-const INDEX_PATH = new URL('index.html', self.location).pathname;
+const SCOPE_URL = new URL(self.registration.scope);
+const SHELL_URL = new URL('index.html', SCOPE_URL).href;
 const ASSETS = [
-  new URL('./', self.location).pathname,
-  new URL('index.html', self.location).pathname,
-  new URL('manifest.json', self.location).pathname,
-  new URL('css/style.css', self.location).pathname,
-  new URL('js/app.js', self.location).pathname,
-  new URL('js/pwa.js', self.location).pathname,
-  new URL('js/limits.js', self.location).pathname,
-  new URL('js/admin-inline.js', self.location).pathname
+  new URL('./', SCOPE_URL).href,
+  SHELL_URL,
+  new URL('manifest.json', SCOPE_URL).href,
+  new URL('css/style.css', SCOPE_URL).href,
+  new URL('js/app.js', SCOPE_URL).href,
+  new URL('js/pwa.js', SCOPE_URL).href,
+  new URL('js/limits.js', SCOPE_URL).href,
+  new URL('js/admin-inline.js', SCOPE_URL).href
   // NOTE: deliberately NOT caching /data.json
 ];
 
@@ -48,10 +49,10 @@ self.addEventListener('fetch', (event) => {
   if (event.request.mode === 'navigate') {
     event.respondWith((async () => {
       const cache = await caches.open(CACHE_NAME);
-      const cached = await cache.match(INDEX_PATH);
+      const cached = await cache.match(SHELL_URL);
       try {
         const fresh = await fetch(event.request);
-        cache.put(INDEX_PATH, fresh.clone());
+        cache.put(SHELL_URL, fresh.clone());
         return fresh;
       } catch (e) {
         return cached || Response.error();


### PR DESCRIPTION
## Summary
- register the service worker using a URL derived from the script location so subdirectory pages resolve the correct script
- normalize precache entries and navigation shell caching to match the service worker scope

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7b46d5ea88321a71dc73e28d28d32