### PR TITLE
Refine periodic refresh for data.json updates

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -17,12 +17,6 @@ function insertPlaceholder(sel, label){
   sel.appendChild(o);
 }
 
-function populate(sel, values){
-  if (!sel) return;
-  sel.innerHTML = '';
-  values.forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; sel.appendChild(o); });
-}
-
 function updateResult(){
   if (!els.result) return;
   const p = els.product && els.product.value;
@@ -35,30 +29,13 @@ function updateResult(){
   els.result.innerHTML = `<b>Recommended PEG:</b> ${r.PEG} — <b>Dilution:</b> ${r.Dilution}%`;
 }
 
-function initSelectors(){
-  const data = window.state.data||[];
-  // Product select (active)
-  if (els.product){ els.product.innerHTML=''; insertPlaceholder(els.product, '— Select product —'); populate(els.product, unique(data,'Product')); els.product.selectedIndex = 0; els.product.value = ''; }
-  // Method & Pressure start disabled until a product is chosen
-  setDisabled(els.method, true, '— Select method —');
-  setDisabled(els.pressure, true, '— Select pressure —');
-
-  // Listeners
-  if (els.product){
-    els.product.addEventListener('change', () => { rebuildDependentSelectors(); if (els.method) { els.method.value = ''; els.method.dispatchEvent(new Event('change')); } if (els.pressure) { els.pressure.value = ''; els.pressure.dispatchEvent(new Event('change')); } updateResult(); });
-  }
-  if (els.method) els.method.addEventListener('change', updateResult);
-  if (els.pressure) els.pressure.addEventListener('change', updateResult);
-
-  updateResult();
-}
-
 async function loadData(){
   try {
     const res = await fetch('data.json?v=' + Date.now(), {cache:'no-cache'});
     const arr = await res.json();
     window.state.data = Array.isArray(arr) ? arr : [];
-    initSelectors();
+    __dataHash = hashObj(window.state.data);
+    refreshSelectors();
     if (els.stamp) els.stamp.textContent = 'Updated: ' + new Date().toLocaleString();
   } catch (e){
     console.error('Failed to load data.json', e);
@@ -66,13 +43,9 @@ async function loadData(){
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
+  wireSelectorEvents();
   await loadData();
-  try {
-    const res = await fetch('data.json?v=' + Date.now(), {cache:'no-store'});
-    const arr = await res.json();
-    __dataHash = hashObj(arr);
-  } catch(e) {}
-  // replaced by smarter scheduler
+  startDataRefreshScheduler();
 });
 
 
@@ -86,23 +59,6 @@ function setDisabled(el, disabled, placeholder){
   el.appendChild(o);
 }
 
-function rebuildDependentSelectors(){
-  const data = window.state.data || [];
-  const p = els.product && els.product.value;
-  // Reset method & pressure to disabled by default
-  setDisabled(els.method, true, '— Select method —');
-  setDisabled(els.pressure, true, '— Select pressure —');
-  if (!p) return;
-  const filtered = data.filter(r => r.Product === p);
-  const methods = [...new Set(filtered.map(r => r.Method))].filter(Boolean);
-  const pressures = [...new Set(filtered.map(r => r.Pressure))].filter(Boolean);
-  els.method.disabled = false;
-  els.pressure.disabled = false;
-  methods.forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; els.method.appendChild(o); });
-  pressures.forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; els.pressure.appendChild(o); });
-}
-
-
 function hashObj(obj){
   try { return btoa(unescape(encodeURIComponent(JSON.stringify(obj)))).slice(0, 32); }
   catch(e){ return Math.random().toString(36).slice(2); }
@@ -110,30 +66,96 @@ function hashObj(obj){
 
 let __dataHash = null;
 
+function getCurrentSelection(){
+  return {
+    product: els.product ? els.product.value : '',
+    method: els.method ? els.method.value : '',
+    pressure: els.pressure ? els.pressure.value : ''
+  };
+}
+
+function refreshSelectors({ preserveProduct = false, preserveDependents = false } = {}){
+  const data = window.state.data || [];
+  const current = getCurrentSelection();
+  const desiredProduct = preserveProduct ? current.product : '';
+  const desiredMethod = preserveDependents ? current.method : '';
+  const desiredPressure = preserveDependents ? current.pressure : '';
+
+  if (els.product){
+    const products = unique(data, 'Product');
+    els.product.innerHTML = '';
+    insertPlaceholder(els.product, '— Select product —');
+    products.forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; els.product.appendChild(o); });
+    if (desiredProduct && products.includes(desiredProduct)){
+      els.product.value = desiredProduct;
+    } else {
+      els.product.value = '';
+    }
+  }
+
+  const activeProduct = els.product && els.product.value;
+  if (!activeProduct){
+    setDisabled(els.method, true, '— Select method —');
+    setDisabled(els.pressure, true, '— Select pressure —');
+    updateResult();
+    return;
+  }
+
+  const filtered = data.filter(r => r.Product === activeProduct);
+  const methods = [...new Set(filtered.map(r => r.Method))].filter(Boolean);
+  const pressures = [...new Set(filtered.map(r => r.Pressure))].filter(Boolean);
+
+  if (els.method){
+    els.method.disabled = false;
+    els.method.innerHTML = '';
+    insertPlaceholder(els.method, '— Select method —');
+    methods.forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; els.method.appendChild(o); });
+    if (desiredMethod && methods.includes(desiredMethod)){
+      els.method.value = desiredMethod;
+    } else {
+      els.method.value = '';
+    }
+  }
+
+  if (els.pressure){
+    els.pressure.disabled = false;
+    els.pressure.innerHTML = '';
+    insertPlaceholder(els.pressure, '— Select pressure —');
+    pressures.forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; els.pressure.appendChild(o); });
+    if (desiredPressure && pressures.includes(desiredPressure)){
+      els.pressure.value = desiredPressure;
+    } else {
+      els.pressure.value = '';
+    }
+  }
+
+  updateResult();
+}
+
+let selectorsWired = false;
+
+function wireSelectorEvents(){
+  if (selectorsWired) return;
+  if (els.product){
+    els.product.addEventListener('change', () => {
+      refreshSelectors({ preserveProduct: true });
+    });
+  }
+  if (els.method) els.method.addEventListener('change', updateResult);
+  if (els.pressure) els.pressure.addEventListener('change', updateResult);
+  selectorsWired = true;
+}
+
 async function refreshDataIfChanged(){
   try {
     const res = await fetch('data.json?v=' + Date.now(), {cache:'no-store'});
     const arr = await res.json();
     const newHash = hashObj(arr);
     if (newHash !== __dataHash){
-      const prev = window.state.data || [];
       window.state.data = Array.isArray(arr) ? arr : [];
       __dataHash = newHash;
 
-      // Try to preserve current selections if still valid
-      const p = els.product && els.product.value;
-      const m = els.method && els.method.value;
-      const pr = els.pressure && els.pressure.value;
-
-      // Rebuild selectors
-      initSelectors();
-
-      // Restore selections when possible
-      if (p && [...els.product.options].some(o => o.value === p)) els.product.value = p;
-      if (m && [...els.method.options].some(o => o.value === m)) els.method.value = m;
-      if (pr && [...els.pressure.options].some(o => o.value === pr)) els.pressure.value = pr;
-
-      updateResult();
+      refreshSelectors({ preserveProduct: true, preserveDependents: true });
       if (els.stamp) els.stamp.textContent = 'Updated: ' + new Date().toLocaleString();
       console.log('data.json updated; UI refreshed.');
     }
@@ -141,3 +163,32 @@ async function refreshDataIfChanged(){
     console.warn('Data refresh check failed', e);
   }
 }
+
+const REFRESH_INTERVAL_MS = 60 * 1000; // 1 minute cadence while the tab is visible
+let refreshTimerId = null;
+
+function startDataRefreshScheduler(){
+  stopDataRefreshScheduler();
+  const tick = () => {
+    if (document.visibilityState !== 'hidden') {
+      refreshDataIfChanged();
+    }
+  };
+  refreshTimerId = setInterval(tick, REFRESH_INTERVAL_MS);
+  tick();
+}
+
+function stopDataRefreshScheduler(){
+  if (refreshTimerId !== null){
+    clearInterval(refreshTimerId);
+    refreshTimerId = null;
+  }
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    startDataRefreshScheduler();
+  } else {
+    stopDataRefreshScheduler();
+  }
+});


### PR DESCRIPTION
## Summary
- capture the initial data.json hash during the first load
- introduce a visibility-aware scheduler to refresh data.json regularly
- pause the polling loop when the page is hidden to avoid unnecessary work
- rebuild selectors through a single refresh helper that preserves choices without duplicating event listeners

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7bcd077288321822a280190253b7d